### PR TITLE
fix: correct Rspack config

### DIFF
--- a/apps/1000/rspack.config.mjs
+++ b/apps/1000/rspack.config.mjs
@@ -1,7 +1,5 @@
 import { defineConfig } from "@rspack/cli";
 
-import TerserPlugin from "terser-webpack-plugin";
-
 const sourceMap = !!process.env.SOURCE_MAP;
 const minify = !!process.env.MINIFY;
 
@@ -28,17 +26,15 @@ export default defineConfig({
 					loader: "builtin:swc-loader",
 					options: {
 						jsc: {
+							target: "es2022",
 							parser: {
 								syntax: "ecmascript",
 								jsx: true,
 							},
 							transform: {
 								react: {
-									pragma: "React.createElement",
-									pragmaFrag: "React.Fragment",
-									throwIfNamespace: true,
+									runtime: "automatic",
 									development: false,
-									useBuiltins: false,
 								},
 							},
 						},

--- a/apps/10000/rspack.config.mjs
+++ b/apps/10000/rspack.config.mjs
@@ -1,7 +1,5 @@
 import { defineConfig } from "@rspack/cli";
 
-import TerserPlugin from "terser-webpack-plugin";
-
 const sourceMap = !!process.env.SOURCE_MAP;
 const minify = !!process.env.MINIFY;
 
@@ -28,17 +26,15 @@ export default defineConfig({
 					loader: "builtin:swc-loader",
 					options: {
 						jsc: {
+							target: "es2022",
 							parser: {
 								syntax: "ecmascript",
 								jsx: true,
 							},
 							transform: {
 								react: {
-									pragma: "React.createElement",
-									pragmaFrag: "React.Fragment",
-									throwIfNamespace: true,
+									runtime: "automatic",
 									development: false,
-									useBuiltins: false,
 								},
 							},
 						},

--- a/apps/3000/rspack.config.mjs
+++ b/apps/3000/rspack.config.mjs
@@ -1,7 +1,5 @@
 import { defineConfig } from "@rspack/cli";
 
-import TerserPlugin from "terser-webpack-plugin";
-
 const sourceMap = !!process.env.SOURCE_MAP;
 const minify = !!process.env.MINIFY;
 
@@ -28,17 +26,15 @@ export default defineConfig({
 					loader: "builtin:swc-loader",
 					options: {
 						jsc: {
+							target: "es2022",
 							parser: {
 								syntax: "ecmascript",
 								jsx: true,
 							},
 							transform: {
 								react: {
-									pragma: "React.createElement",
-									pragmaFrag: "React.Fragment",
-									throwIfNamespace: true,
+									runtime: "automatic",
 									development: false,
-									useBuiltins: false,
 								},
 							},
 						},

--- a/apps/5000/rspack.config.mjs
+++ b/apps/5000/rspack.config.mjs
@@ -1,7 +1,5 @@
 import { defineConfig } from "@rspack/cli";
 
-import TerserPlugin from "terser-webpack-plugin";
-
 const sourceMap = !!process.env.SOURCE_MAP;
 const minify = !!process.env.MINIFY;
 
@@ -28,17 +26,15 @@ export default defineConfig({
 					loader: "builtin:swc-loader",
 					options: {
 						jsc: {
+							target: "es2022",
 							parser: {
 								syntax: "ecmascript",
 								jsx: true,
 							},
 							transform: {
 								react: {
-									pragma: "React.createElement",
-									pragmaFrag: "React.Fragment",
-									throwIfNamespace: true,
+									runtime: "automatic",
 									development: false,
-									useBuiltins: false,
 								},
 							},
 						},

--- a/apps/rome/rspack.config.mjs
+++ b/apps/rome/rspack.config.mjs
@@ -41,6 +41,7 @@ export default defineConfig({
 				loader: "builtin:swc-loader",
 				options: {
 					jsc: {
+						target: "es2022",
 						parser: {
 							syntax: "typescript",
 						},


### PR DESCRIPTION
Update Rspack configuration to be consistent with other tools:

- Target should use es2022 (the same as rolldown)
- React JSX runtime should be used
- Remove unused `import TerserPlugin from "terser-webpack-plugin";`