### PR TITLE
chore: add shared Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["helpers:pinGitHubActionDigestsToSemver"],
+  "extends": ["github>Boshen/renovate", "helpers:pinGitHubActionDigestsToSemver"],
   "timezone": "Asia/Shanghai",
   "automerge": true,
   "automergeType": "pr",


### PR DESCRIPTION
## Summary
- add or normalize `.github/renovate.json`
- make `github>Boshen/renovate` the first Renovate preset

## Verification
- parsed `.github/renovate.json` with `jq`
- verified `.extends[0] == "github>Boshen/renovate"`