### PR TITLE
chore(deps): remove deprecated `@types/glob`

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
 	"dependencies": {
 		"@iconify-icons/material-symbols": "1.2.58",
 		"@iconify/react": "6.0.2",
-		"@types/glob": "9.0.0",
 		"react": "19.2.6",
 		"react-dom": "19.2.6"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       '@iconify/react':
         specifier: 6.0.2
         version: 6.0.2(react@19.2.6)
-      '@types/glob':
-        specifier: 9.0.0
-        version: 9.0.0
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -1241,10 +1238,6 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
-
-  '@types/glob@9.0.0':
-    resolution: {integrity: sha512-00UxlRaIUvYm4R4W9WYkN8/J+kV8fmOQ7okeH6YFtGWFMt3odD45tpG5yA5wnL7HE6lLgjaTW5n14ju2hl2NNA==}
-    deprecated: This is a stub types definition. glob provides its own type definitions, so you do not need this installed.
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -2807,10 +2800,6 @@ snapshots:
       '@types/json-schema': 7.0.15
 
   '@types/estree@1.0.8': {}
-
-  '@types/glob@9.0.0':
-    dependencies:
-      glob: 13.0.6
 
   '@types/json-schema@7.0.15': {}
 


### PR DESCRIPTION
`@types/glob` is a stub types package; glob provides its own type definitions, so the dependency is unnecessary.