### PR TITLE
chore(bench): include rollup in benchmark suite

### DIFF
--- a/bench.mjs
+++ b/bench.mjs
@@ -74,11 +74,12 @@ function escapeShellArg(arg) {
 }
 
 // Run benchmark for all tools
-const tools = ['vite', 'rsbuild', 'rspack', 'rolldown', 'esbuild', 'bun'];
+const tools = ['vite', 'rsbuild', 'rspack', 'rollup', 'rolldown', 'esbuild', 'bun'];
 const toolDisplayNames = {
   'vite': 'vite',
   'rsbuild': 'rsbuild',
   'rspack': 'rspack',
+  'rollup': 'rollup',
   'rolldown': 'rolldown',
   'esbuild': 'esbuild',
   'bun': 'bun'
@@ -177,6 +178,7 @@ function getToolVersions() {
     'vite': 'pnpm vite --version',
     'rsbuild': 'pnpm rsbuild --version',
     'rspack': 'pnpm rspack --version',
+    'rollup': 'pnpm rollup --version',
     'rolldown': 'pnpm rolldown --version',
     'esbuild': 'pnpm esbuild --version',
     'bun': 'bun --version',


### PR DESCRIPTION
## Summary

- Add `rollup` to the `tools` array in `bench.mjs` so it participates in every hyperfine run alongside vite, rsbuild, rspack, rolldown, esbuild, and bun.
- Register `rollup` in `toolDisplayNames` and in `getToolVersions`'s `toolCommandMap` (`pnpm rollup --version`) so the markdown table shows its real version.
- Order matches `scripts/output-size.mjs` (`rspack` → `rollup` → `rolldown`) to keep the two scripts consistent.

## Why

The README's benchmark tables are auto-generated from `bench.mjs` output via `scripts/update-readme.mjs`, but rollup was missing from the tools list — even though every app under `apps/*` already ships a `build:rollup` script and a `rollup.config.mjs`. Excluding it from the bench means the published comparison is incomplete, which undercuts the repo's purpose. CI runtime is a fair concern, but data integrity wins here.

## Impact

- README's three tables (Ubuntu / macOS / Windows) will gain a `rollup` row on the next `main` push.
- No breaking changes to the script's CLI, output schema, or JSON export shape — `displayResults` already sizes columns dynamically, and `dist-rollup` is created by hyperfine during the run, so size measurements work without any extra setup.
- CI wall-clock will increase per OS by however long rollup takes on `apps/10000` × hyperfine's run count. Acceptable trade-off for completeness.