### PR TITLE
chore: bump root pnpm to 11.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "performance-compare-ext",
 	"version": "1.0.0",
 	"license": "ISC",
-	"packageManager": "pnpm@10.33.0",
+	"packageManager": "pnpm@11.1.2",
 	"scripts": {
 		"bench": "node bench.mjs"
 	},


### PR DESCRIPTION
## Summary
- bump the root `packageManager` pin to `pnpm@11.1.2`
- keep the change scoped to the top-level `package.json` only
- avoid lockfile, workflow, docs, and nested package changes

## Testing
- not run (root packageManager metadata change only)