### PR TITLE
Standardize esbuild sourcemap flag across all benchmark apps

### DIFF
--- a/apps/10000/package.json
+++ b/apps/10000/package.json
@@ -9,8 +9,8 @@
     "build:rolldown": "rolldown build --config rolldown.config.mjs",
     "build:rspack": "rspack build --config rspack.config.mjs",
     "build:rollup": "rollup --config rollup.config.mjs",
-    "build:esbuild": "esbuild ./src/index.jsx --bundle --outdir=dist-esbuild --minify --sourcemap --legal-comments=none",
-    "build:bun": "bun build --outdir=dist-bun --production --sourcemap ./src/index.jsx "
+    "build:esbuild": "esbuild ./src/index.jsx --bundle --outdir=dist-esbuild --minify --sourcemap",
+    "build:bun": "bun build ./src/index.jsx --outdir=dist-bun --production --sourcemap"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
The esbuild build script for apps/10000 includes `--legal-comments=none` and a slightly different bun build script. To ensure consistent benchmarking, remove `--legal-comments=none` from esbuild and align the bun build script format with other apps, ensuring all esbuild and bun commands are identical across the 1000, 3000, 5000, and 10000 apps.