### PR TITLE
ci: exempt rolldown from pnpm minimumReleaseAge policy

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,8 @@ packages:
 
 onlyBuiltDependencies:
   - bun
+
+# Always benchmark the latest rolldown; exempt it from the minimumReleaseAge policy.
+minimumReleaseAgeExclude:
+  - rolldown
+  - '@rolldown/*'


### PR DESCRIPTION
## Problem

CI runs `pnpm install --frozen-lockfile`, which the runner enforces under a 24h `minimumReleaseAge` supply-chain policy. When a bundler-update PR bumps `rolldown` to a just-published version, the lockfile entries for `rolldown` and all `@rolldown/binding-*` packages are "too new" and the install fails:

```
[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] 16 lockfile entries failed verification:
  rolldown@1.1.0 was published at ..., within the minimumReleaseAge cutoff
  @rolldown/binding-darwin-arm64@1.1.0 ...
  ...
```

This breaks the benchmark CI on every rolldown update (e.g. #214).

## Fix

Add pnpm's `minimumReleaseAgeExclude` to `pnpm-workspace.yaml` to exempt `rolldown` and `@rolldown/*` from the age check. The whole purpose of this repo is to benchmark the **latest** rolldown, so it should never be held back by the release-age policy.

## Verification

Reproduced the runner's check locally (`npm_config_minimum_release_age=1440 pnpm install --frozen-lockfile`):

- **without** the exclude → identical 16-entry failure to CI
- **with** the exclude → install passes

`@rolldown/*` compiles to the anchored regex `^@rolldown/.*$`, covering every `@rolldown/binding-*` entry; `rolldown` matches the main package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)