### PR TITLE
fix: run native sourcemap benchmark on JSX

### DIFF
--- a/plugins/sourcemap.js
+++ b/plugins/sourcemap.js
@@ -101,7 +101,7 @@ onClick={() => {
 export const oxcNative = {
 	name: "oxc+nativeMagicString",
 	transform(code, id, meta) {
-		if (id.endsWith(".jsx")) return null;
+		if (!id.endsWith(".jsx")) return null;
 
 		let { magicString: ms, ast } = meta;
 


### PR DESCRIPTION
The JavaScript `MagicString` variants return early for files that are **not** `.jsx`, but the native variant had the inverse condition and returned early for every `.jsx` file. You can compare the [existing OXC JavaScript filter with the native filter directly](https://github.com/rolldown/benchmarks/blob/39395e9d5761f818f177d2a917bf3b8e49ea383f/plugins/sourcemap.js#L56-L104).

As a result, the native run skipped the transformation workload while the comparison runs parsed, traversed, modified, and generated source maps for JSX modules.

This means the existing native results in `sourcemap.md`, which are also referenced by the [Rolldown native MagicString documentation](https://rolldown.rs/in-depth/native-magic-string), were not measuring equivalent work and should be regenerated after this fix.
